### PR TITLE
Upgraded msbuild and fixed unmatched release files

### DIFF
--- a/{{cookiecutter.plugin_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.plugin_name}}/.github/workflows/release.yml
@@ -30,15 +30,14 @@ jobs:
         path: plugin\bakkesmodsdk
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.1
 {% raw %}
     - name: Build
-      run: msbuild /m /p:Configuration=Release /p:BakkesModPath=$env:GITHUB_WORKSPACE\plugin /p:Environment=GitHub $env:GITHUB_WORKSPACE\plugin\${{ env.SOLUTION_NAME }}.sln
+      run: msbuild /m /p:Configuration=Release /p:BakkesModPath=${{ github.workspace }}\plugin /p:Environment=GitHub ${{ github.workspace }}\plugin\${{ env.SOLUTION_NAME }}.sln
 
     - name: Create Release
       uses: softprops/action-gh-release@v1
       with:
-        files: ${{ github.workspace }}\plugin\plugins\${{ env.SOLUTION_NAME }}.dll
-      env:
-        GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+        fail_on_unmatched_files: true
+        files: plugin/plugins/${{ env.SOLUTION_NAME }}.dll
 {% endraw %}


### PR DESCRIPTION
Fixes "Node.js 12 actions are deprecated" error due to old msbuild setup step.

That forced the update for the ${{ github.workspace }} in the msbuild command line and the file path for the release action - somehow it doesn't want to use backslashes anymore.